### PR TITLE
♻️ 내정보 수정 페이지 API 연동 및 로그아웃 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,11 @@ const nextConfig: NextConfig = {
         hostname: 'placehold.co',
         port: '',
       },
+      {
+        protocol: 'https',
+        hostname: 'lastpang-file-bucket.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+      },
     ],
   },
 };

--- a/src/app/(auth)/action.ts
+++ b/src/app/(auth)/action.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { BASE_URL } from '@/constant';
+import { BaseResType } from '@/types/hanaHakdang';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import {
@@ -111,7 +112,13 @@ export async function login(
     body: JSON.stringify(value),
   });
 
-  console.log(`Status: ${res.status}`);
+  if (!res.ok) {
+    return {
+      value: value,
+      message: '이메일 또는 비밀번호가 일치하지 않습니다.',
+      isError: true,
+    } as ActionResType<LoginType, string>;
+  }
 
   const c = res.headers.getSetCookie();
   const cookieStore = await cookies();

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -7,15 +7,16 @@ import IconBadge from '@/components/atoms/IconBadge';
 import Input from '@/components/atoms/Input';
 import { AiFillEye } from 'react-icons/ai';
 import { MdArrowOutward } from 'react-icons/md';
+import { toast } from 'react-toastify';
 import Link from 'next/link';
-import { useActionState, useState } from 'react';
+import { useActionState, useEffect, useState } from 'react';
 
 export default function Page() {
   const [hide, setHide] = useState(false);
   const [rememberId, setRememberId] = useState(false);
   const [state, formAction] = useActionState(login, {
     value: { email: '', password: '' },
-    message: '로그인 안됨',
+    message: '',
     isError: false,
   });
 
@@ -26,6 +27,12 @@ export default function Page() {
       return newHide;
     });
   };
+
+  useEffect(() => {
+    if (state.isError && state.message) {
+      toast.warning(state.message);
+    }
+  }, [state]);
 
   return (
     <form action={formAction}>

--- a/src/app/(main)/mypage/account-settings/page.tsx
+++ b/src/app/(main)/mypage/account-settings/page.tsx
@@ -1,36 +1,38 @@
 'use client';
 
-import { getAccountData } from '@/app/(main)/mypage/actions';
 import { changeProfileForm } from '@/app/action';
 import Button from '@/components/atoms/Button';
 import Input from '@/components/atoms/Input';
+import { useAuthStore } from '@/context/AuthContext';
 import { AiFillEye } from 'react-icons/ai';
+import { toast } from 'react-toastify';
 import Image from 'next/image';
-import { useActionState, useState } from 'react';
+import {
+  ChangeEvent,
+  useActionState,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
-export default async function Page() {
-  const {
-    name: userName,
-    profileImage: userImage,
-    birth: birthDate,
-  } = await getAccountData();
+export default function Page() {
+  const { auth, loading, fetchAuth } = useAuthStore((state) => state);
   const [hide, setHide] = useState(false);
+  const birthDateRef = useRef('2024년 10월 10일');
   const [showNewImage, setShowNewImage] = useState<string | null>(null);
   const [newImage, setNewImage] = useState<File | null>(null);
   const [state, formAction] = useActionState(changeProfileForm, {
     value: {
       newImage: newImage,
-      newBirthDate: '',
       currentPassword: '',
       newPassword: '',
       newConfirmedPassword: '',
-      newUserName: '',
     },
-    message: '프로필 폼 변경 이전',
+    message: '',
     isError: false,
   });
 
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
       const reader = new FileReader();
@@ -50,6 +52,15 @@ export default async function Page() {
     });
   };
 
+  useEffect(() => {
+    if (state.isError && state.message) {
+      toast.warning(state.message);
+    } else if (!state.isError && state.message) {
+      toast.info(state.message);
+      fetchAuth();
+    }
+  }, [state]);
+
   return (
     <form
       className="flex flex-col justify-center items-center"
@@ -58,30 +69,46 @@ export default async function Page() {
       <div className="text-xl font-bold my-4">프로필 변경</div>
       <div className="relative w-64 h-64 my-4">
         <label htmlFor="profile-image-upload" className="cursor-pointer">
-          <Image
-            className="rounded-full object-cover"
-            src={showNewImage || userImage}
-            alt="Profile Image"
-            fill
-          />
+          {loading || !auth ? (
+            <div className="animate-pulse w-full h-full">
+              <div className="w-full h-full bg-gray-200 rounded-full"></div>
+            </div>
+          ) : (
+            <Image
+              className="rounded-full object-cover"
+              src={showNewImage ?? auth.profileImage}
+              alt="Profile Image"
+              fill
+            />
+          )}
         </label>
         <input
           id="profile-image-upload"
+          name="profile-image-upload"
           type="file"
           accept="image/*"
           className="hidden"
           onChange={handleImageChange}
         />
       </div>
-      <div>{userName}</div>
-      <div>{birthDate}</div>
+      {loading || !auth ? (
+        <div className="animate-pulse flex items-center gap-y-1 flex-col">
+          <div className="w-11 h-6 bg-gray-200 rounded"></div>
+          <div className="w-32 h-6 bg-gray-200 rounded"></div>
+        </div>
+      ) : (
+        <>
+          <div>{auth.name}</div>
+          <div>{birthDateRef.current}</div>
+        </>
+      )}
       <hr className="border-t border-gray-300" />
       <div className="my-6 grid grid-rows-3 gap-3 w-96">
         <Input
           name="currentPassword"
           label="현재 비밀번호"
           placeholder="현재 비밀번호를 입력하세요."
-          defaultValue={state.value.currentPassword}
+          defaultValue={state.value.currentPassword ?? undefined}
           type={hide ? 'text' : 'password'}
           className="my-2 text-gray-400 bg-white"
         >
@@ -91,17 +118,17 @@ export default async function Page() {
           name="newPassword"
           label="새 비밀번호"
           placeholder="새 비밀번호를 입력하세요."
-          defaultValue={state.value.newPassword}
+          defaultValue={state.value.newPassword ?? undefined}
           type={hide ? 'text' : 'password'}
           className="my-2 text-gray-400 bg-white"
         >
           <AiFillEye className="cursor-pointer" onClick={onToggleHide} />
         </Input>
         <Input
-          name="password"
+          name="newConfirmedPassword"
           label="새 비밀번호 확인"
           placeholder="새 비밀번호를 다시 한 번 입력하세요."
-          defaultValue={state.value.newConfirmedPassword}
+          defaultValue={state.value.newConfirmedPassword ?? undefined}
           type={hide ? 'text' : 'password'}
           className="my-2 text-gray-400 bg-white"
         >

--- a/src/app/(main)/mypage/actions.ts
+++ b/src/app/(main)/mypage/actions.ts
@@ -68,11 +68,9 @@ export async function ModifyProfile(
   });
 
   const data = await res.json();
-
   if (!res.ok) {
     console.log(data.message);
   }
-
   return data.message;
 }
 

--- a/src/app/(main)/mypage/card-settings/page.tsx
+++ b/src/app/(main)/mypage/card-settings/page.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/atoms/Button';
 import MyCardCareerForm from '@/components/template/MyCardCareerForm';
 import MyCardIntroductionForm from '@/components/template/MyCardIntroductionForm';
 import MyCardProfileForm from '@/components/template/MyCardProfileForm';
+import { DEFAULT_PROFILE_URL } from '@/constant';
 import { useAuthStore } from '@/context/AuthContext';
 import { FaQuoteLeft, FaQuoteRight } from 'react-icons/fa6';
 import { RiPencilFill } from 'react-icons/ri';
@@ -18,7 +19,7 @@ import { startTransition, useActionState, useEffect, useState } from 'react';
 export default function Page() {
   const { auth, loading } = useAuthStore((state) => state);
   const mentoName = auth ? auth.name : '';
-  const userImage = 'https://placehold.co/25x25';
+  const userImage = auth ? auth.profileImage : DEFAULT_PROFILE_URL;
   const [modifyMode, setModifyMode] = useState(false);
   const [profileData, setProfileData] = useState<ProfileResponseType | null>(
     null

--- a/src/app/action.ts
+++ b/src/app/action.ts
@@ -7,6 +7,7 @@ import {
   SubmitReviewFormType,
   AuthType,
   ChangeProfileFormType,
+  ChangeProfileRequestType,
 } from '@/types/hanaHakdang';
 import { checkAuthAndGetCookie } from '@/utils/CheckCookies';
 
@@ -20,12 +21,62 @@ export async function changeProfileForm(
   prevState: ActionResType<ChangeProfileFormType, string>,
   formData: FormData
 ): Promise<ActionResType<ChangeProfileFormType, string>> {
-  const value = Object.fromEntries(formData) as ChangeProfileFormType;
-  const message = '프로필 폼 데이터 변경 액션';
+  const jsessionIdCookie = await checkAuthAndGetCookie();
+  const formObj: ChangeProfileFormType = {
+    newImage: formData.get('profile-image-upload') as File | null,
+    currentPassword: formData.get('currentPassword') as string | null,
+    newPassword: formData.get('newPassword') as string | null,
+    newConfirmedPassword: formData.get('newConfirmedPassword') as string | null,
+  };
+
+  const reqFormData = new FormData();
+  if (formObj.newImage) {
+    reqFormData.append('imageFile', formObj.newImage);
+  }
+  if (
+    formObj.currentPassword &&
+    formObj.newPassword &&
+    formObj.newConfirmedPassword
+  ) {
+    reqFormData.append(
+      'accountData',
+      new Blob(
+        [
+          JSON.stringify({
+            currentPassword: formObj.currentPassword,
+            newPassword: formObj.newPassword,
+            confirmPassword: formObj.newConfirmedPassword,
+          }),
+        ],
+        { type: 'application/json' }
+      )
+    );
+  }
+
+  const res = await fetch(BASE_URL + '/account', {
+    method: 'PATCH',
+    headers: {
+      Cookie: `${jsessionIdCookie?.name}=${jsessionIdCookie?.value}`,
+    },
+    body: reqFormData,
+  });
+
+  if (!res.ok) {
+    return {
+      value: {
+        ...formObj,
+        newImage: null,
+      },
+      message: '잘못된 요청입니다.',
+      isError: true,
+    };
+  }
+
+  const data = (await res.json()) as BaseResType<ChangeProfileFormType>;
 
   return {
-    value: value,
-    message: message,
+    value: prevState.value,
+    message: data.message,
     isError: false,
   };
 }

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,13 @@
+import { SESSION_COOKIE_NAME } from '@/constant';
+import { cookies } from 'next/headers';
+
+export async function POST() {
+  const cookieStore = await cookies();
+  cookieStore.delete(SESSION_COOKIE_NAME);
+  return new Response(null, {
+    status: 200,
+    headers: {
+      'Set-Cookie': cookieStore.toString(),
+    },
+  });
+}

--- a/src/components/molecules/ProfileDropdown.tsx
+++ b/src/components/molecules/ProfileDropdown.tsx
@@ -5,23 +5,26 @@ import Dropdown from '@/components/atoms/Dropdown';
 import { AuthType } from '@/types/hanaHakdang';
 import { HiOutlineUserCircle } from 'react-icons/hi2';
 import { PiShoppingBagOpen, PiUser, PiArrowSquareOut } from 'react-icons/pi';
+import Image from 'next/image';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
-
-function deleteCookie(name: string) {
-  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
-  console.log(`${name} 쿠키가 삭제되었습니다.`);
-  redirect('/login');
-}
+import { useCallback } from 'react';
 
 interface Props {
   authData: AuthType;
+  fetchAuth: () => void;
 }
 
-export default function ProfileDropdown(props: Props) {
-  const { name, role, profileImage } = props.authData;
+export default function ProfileDropdown({ authData, fetchAuth }: Props) {
+  const { name, role, profileImage } = authData;
   //TODO: 임시 이미지 설정, userImage 받아 와야함
-  const userImage = 'https://placehold.co/40x40/orange/white';
+
+  const logOut = useCallback(async () => {
+    await fetch('/api/logout', {
+      method: 'POST',
+    });
+    fetchAuth();
+    location.reload();
+  }, []);
 
   const menuItems = [
     <div>
@@ -52,11 +55,7 @@ export default function ProfileDropdown(props: Props) {
       </div>
       <div className="text-xs px-2">마이 페이지</div>
     </Link>,
-    <Button
-      className="flex my-2 items-center"
-      type="button"
-      onClick={() => deleteCookie('JSESSIONID')}
-    >
+    <Button className="flex my-2 items-center" type="button" onClick={logOut}>
       <div className="flex items-center justify-center bg-gray-100 rounded-lg p-2">
         <PiArrowSquareOut />
       </div>
@@ -67,11 +66,14 @@ export default function ProfileDropdown(props: Props) {
   return (
     <Dropdown
       menuButton={
-        <img
-          className="w-full h-full rounded-full"
-          src={profileImage ?? userImage}
-          alt="Profile Image"
-        />
+        <div className="relative h-10 w-10 rounded-full">
+          <Image
+            style={{ borderRadius: '100%' }}
+            fill
+            src={profileImage}
+            alt="Profile Image"
+          />
+        </div>
       }
       menuItems={menuItems}
       anchor={'bottom start'}

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export default function Header({ children }: Props) {
-  const { auth, loading } = useAuthStore((state) => state);
+  const { auth, loading, fetchAuth } = useAuthStore((state) => state);
   const items = ['start', 'modify', 'start'];
 
   const loginStatus = !!auth;
@@ -47,7 +47,7 @@ export default function Header({ children }: Props) {
                   lectureTitle="주식 투자 성공기"
                   lectureTime="2024-01-10 15:00"
                 />
-                <ProfileDropdown authData={auth} />
+                <ProfileDropdown authData={auth} fetchAuth={fetchAuth} />
               </div>
             ) : (
               <LinkButton

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -6,6 +6,8 @@ export const BASE_HEADERS: HeadersInit = {
   'Content-type': 'application/json',
 };
 
+export const DEFAULT_PROFILE_URL = 'https://placehold.co/40x40/orange/white';
+
 export const STOMP_BROKER_URL = 'ws://ws.hanahakhoe.shop/classroom';
 // export const STOMP_BROKER_URL = 'ws://localhost:8081/classroom';
 

--- a/src/provider/AuthRefreshProvider.tsx
+++ b/src/provider/AuthRefreshProvider.tsx
@@ -7,12 +7,13 @@ import { ReactNode, useEffect } from 'react';
 interface Props {
   children: ReactNode;
 }
+
 export default function AuthRefreshProvider({ children }: Props) {
   const pathname = usePathname();
-  const fetchAuth = useAuthStore((state) => state.fetchAuth);
+  const { auth, fetchAuth } = useAuthStore((state) => state);
 
   useEffect(() => {
-    if (pathname === '/') {
+    if (!auth) {
       fetchAuth();
     }
   }, [pathname]);

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -1,5 +1,14 @@
+import { DEFAULT_PROFILE_URL } from '@/constant';
 import { AuthType } from '@/types/hanaHakdang';
 import { createStore } from 'zustand/vanilla';
+
+type AuthResType = {
+  userId: number;
+  name: string;
+  role: string;
+  profileImageUrl?: string;
+  birth?: string;
+};
 
 export type AuthState = {
   auth: AuthType | null;
@@ -27,8 +36,13 @@ export const createAuthStore = (initState: AuthState = defaultInitState) => {
         const res = await fetch('/api/user-info', {
           method: 'GET',
         });
-        const data = (await res.json()) as AuthType;
-        set({ auth: data });
+        const data = (await res.json()) as AuthResType;
+        set({
+          auth: {
+            ...data,
+            profileImage: data.profileImageUrl ?? DEFAULT_PROFILE_URL,
+          },
+        });
       } catch (error) {
         console.log(error);
         return;

--- a/src/types/hanaHakdang.d.ts
+++ b/src/types/hanaHakdang.d.ts
@@ -14,7 +14,7 @@ export type AuthType = {
   userId: number;
   name: string;
   role: string;
-  profileImage?: string;
+  profileImage: string;
 };
 
 export type ChatResponseType = {
@@ -38,11 +38,20 @@ export type ReducerAction<T> = {
 
 export type ChangeProfileFormType = {
   newImage: File | null;
-  newUserName: string;
-  newBirthDate: string;
-  currentPassword: string;
-  newPassword: string;
-  newConfirmedPassword: string;
+  currentPassword: string | null;
+  newPassword: string | null;
+  newConfirmedPassword: string | null;
+};
+
+export type ChangeProfileRequestType = {
+  imageFile: File | null;
+  accountData?: PasswordChangeRequestType;
+};
+
+export type PasswordChangeRequestType = {
+  currentPassword: string | null;
+  newPassword: string | null;
+  confirmPassword: string | null;
 };
 
 export type SubmitReviewFormType = {


### PR DESCRIPTION
## 변경사항

### AS-IS

[//]: # '이 PR에서 어떤점들이 변경되었는지 기술해주세요.'

- 로그아웃 기능 추가됐습니다.
- 내정보 페이지에서 내 계정 정보(비밀번호, 프로필사진) 수정 API 연동 완료했습니다.

### TO-BE

[//]: # '해당 PR이 merge 되고 난 후 develop or main 브랜치에 줄 수 있는 영향 설명, 앞으로 할 작업 정리'

- authData(내 정보)에서 프로필 사진은 API에서 없을 때는 기본 이미지 값(DEFAULT_PROFILE_URL)이 됩니다.(null X)
- 따라서, 이 이미지는 나중에 예쁜걸로 변경해주시면 됩니다.

## 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->

- [ ] 테스트 코드
- [ ] API 테스트

## ETC.
